### PR TITLE
20220124

### DIFF
--- a/Tools/Dependabot/dependabot-orchestrator.yml
+++ b/Tools/Dependabot/dependabot-orchestrator.yml
@@ -13,6 +13,8 @@ variables:
     value: tingle/dependabot-azure-devops:0.5
   - name: privateNugetFeedUrl
     value: "<nuget-feed>"
+  - name: packagesToIgnore
+    value: '[{"dependency-name":"Microsoft.Azure.WebJobs.Extensions.Storage"}]'
 
 stages:
   - stage: CheckDependencies
@@ -64,3 +66,4 @@ stages:
                 - Repository: "repository-2"
                   Directory: "/src"
                   TargetBranch: "my-branch"
+                  PackagesToIgnore: "$(packagesToIgnore)"

--- a/Tools/Dependabot/dependabot-pipeline.yml
+++ b/Tools/Dependabot/dependabot-pipeline.yml
@@ -11,10 +11,11 @@ steps:
           ${{ if ne(value.TargetBranch, '') }}:
             targetBranch: ${{ value.TargetBranch }}
           openPullRequestsLimit: 10
+          # Optional: When not using workitems, remove this item.
           milestone: $(workItemId)
           azureDevOpsAccessToken: "$(PATForAzureDevops)"
           # The ':' at the end of the token is deliberate. Please see ticket: https://github.com/tinglesoftware/dependabot-azure-devops/issues/50_
-          extraEnvironmentVariables: DEPENDABOT_EXTRA_CREDENTIALS=[{"type":"nuget_feed","token":"$(PATForNugetFeed):","url":"$(privateNugetFeedUrl)"}];
+          extraEnvironmentVariables: DEPENDABOT_EXTRA_CREDENTIALS=[{"type":"nuget_feed","token":"$(PATForNugetFeed):","url":"$(privateNugetFeedUrl)"}];DEPENDABOT_IGNORE_CONDITIONS=${{ value.PackagesToIgnore }};
           targetRepositoryName: "${{ value.Repository }}"
           ${{ if ne(value.Directory, '') }}:
             directory: "${{ value.Directory }}"

--- a/Wiki/Azure/Azure-CLI-Snippets/AppInsights.md
+++ b/Wiki/Azure/Azure-CLI-Snippets/AppInsights.md
@@ -20,8 +20,10 @@ You can set this up for:
 
 ## Logging
 
-You have the ability to disable the diagnostic settings for your Application Insights. When you want to do this, add the switch `DiagnosticSettingsDisabled`. Next to that, you have the ability to specify which set of diagnostic logs you would like to enable.
+You have the ability to enable the diagnostic settings for your Application Insights. When you want to do this, make sure to add the `DiagnosticSettingsLogAnalyticsWorkspaceResourceId` to your pipeline. _Make sure that this is a different workspace than you have defined for Application Insights, since it will result in duplicate logging._
+
+Next to that, you have the ability to specify which set of diagnostic logs you would like to enable.
 
 For the category `logs` the parameter `DiagnosticSettingsLogs` can be used and for the category `metrics` the parameter `DiagnosticSettingsMetrics`. If you do not specify these settings, the default set (everything) will be enabled for your resource.
 
-These logs get written to the Log Analytics Workspace that you specified.
+By default, the diagnostic settings are turned off for your Application Insights instance.

--- a/Wiki/Azure/Azure-CLI-Snippets/AppInsights/Create-AppInsights-Resource.md
+++ b/Wiki/Azure/Azure-CLI-Snippets/AppInsights/Create-AppInsights-Resource.md
@@ -15,7 +15,7 @@ Some parameters from [General Parameter](/Azure/Azure-CLI-Snippets) list.
 | LogAnalyticsWorkspaceResourceId | <input type="checkbox"> | `/subscriptions/<subscriptionid>/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<loganalyticsworkspacename>` | The log analytics workspace that Application Insights can be linked to |
 | DiagnosticSettingsLogs | <input type="checkbox"> | `@('Requests';'MongoRequests';)` | If you want to enable a specific set of diagnostic settings for the category 'Logs'. By default, all categories for 'Logs' will be enabled. |
 | DiagnosticSettingsMetrics | <input type="checkbox"> | `@('Requests';'MongoRequests';)` | If you want to enable a specific set of diagnostic settings for the category 'Metrics'. By default, all categories for 'Metrics' will be enabled. |
-| DiagnosticSettingsDisabled | <input type="checkbox"> | n.a. | If you don't want to enable any diagnostic settings, you can pass this as a switch witout a value(`-DiagnosticsettingsDisabled`). |
+| DiagnosticSettingsLogAnalyticsWorkspaceResourceId | <input type="checkbox"> | `/subscriptions/<subscriptionid>/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<loganalyticsworkspacename>` | The log analytics workspace that you want to link your diagnostic settings to. _Make sure this is not the same as the one that is linked to your Application Insights instance, since it can result in duplicate logging._ |
 
 # YAML
 
@@ -29,7 +29,7 @@ Be aware that this YAML example contains all parameters that can be used with th
     azureSubscription: "${{ parameters.SubscriptionName }}"
     scriptType: pscore
     scriptPath: "$(Pipeline.Workspace)/AzDocs/AppInsights/Create-AppInsights-Resource.ps1"
-    arguments: "-AppInsightsName '$(AppInsightsName)' -AppInsightsResourceGroupName '$(AppInsightsResourceGroupName)' -AppInsightsLocation '$(AppInsightsLocation)' -LogAnalyticsWorkspaceResourceId '$(LogAnalyticsWorkspaceResourceId)' -DiagnosticSettingsLogs $(DiagnosticSettingsLogs) -DiagnosticSettingsDisabled $(DiagnosticSettingsDisabled)"
+    arguments: "-AppInsightsName '$(AppInsightsName)' -AppInsightsResourceGroupName '$(AppInsightsResourceGroupName)' -AppInsightsLocation '$(AppInsightsLocation)' -LogAnalyticsWorkspaceResourceId '$(LogAnalyticsWorkspaceResourceId)' -DiagnosticSettingsLogs $(DiagnosticSettingsLogs) -DiagnosticSettingsMetrics '$(DiagnosticSettingsMetrics)' -DiagnosticSettingsLogAnalyticsWorkspaceResourceId '$(DiagnosticSettingsLogAnalyticsWorkspaceResourceId)'
 ```
 
 # Code

--- a/Wiki/Azure/Azure-CLI-Snippets/Functions/Set-App-Key-on-Function-App.md
+++ b/Wiki/Azure/Azure-CLI-Snippets/Functions/Set-App-Key-on-Function-App.md
@@ -1,0 +1,49 @@
+[[_TOC_]]
+
+# Description
+
+This snippet will set an app key on your functionapp. It allows you to set the app keys for specific slots or all slots.
+The slot you apply this to will have to be started, otherwise the script will fail (usually production slot if DeploymentSlotName is not set). 
+If ApplyToAllSlots is set to true, the script will check if the additional slots are stopped, if they are it will attempt to start the slot, make the change and stop it again. 
+
+# Parameters
+
+Some parameters from [General Parameter](/Azure/Azure-CLI-Snippets) list.
+| Parameter                     | Required                        | Example Value                               | Description                                                                             |
+| ----------------------------- | ------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------- |
+| FunctionAppResourceGroupName  | <input type="checkbox" checked> | `MyTeam-SomeApi-$(Release.EnvironmentName)` | The resourcegroup where the FunctionApp resides in.                                     |
+| FunctionAppName               | <input type="checkbox" checked> | `FunctionApp-name`                          | Name of the FunctionApp to set the whitelist on.                                        |
+| FunctionAppAppKeyName         | <input type="checkbox" checked> | `exampleKeyName`                            | Name of the app key.                                                                    |
+| FunctionAppAppKeyType         | <input type="checkbox">         | `functionKeys`/`masterKey`/`systemKey`      | Type of the app key. Defaults to functionKeys                                           |
+| FunctionAppDeploymentSlotName | <input type="checkbox">         | `staging`                                   | Name of the slot to apply the app key to                                                |
+| ApplyToAllSlots               | <input type="checkbox">         | `$true`                                   | The slot to apply the app key to                                                        |
+| RetryApplyToAllSlotsCount     | <input type="checkbox">         | `5`                                   | Retry count for applying the key to a slot when ApplyToAllSlots is true. Defaults to 3. |
+
+# YAML
+
+Be aware that this YAML example contains all parameters that can be used with this script. You'll need to pick and choose the parameters that are needed for your desired action.
+
+```yaml
+- task: AzureCLI@2
+  displayName: "Set AppSettings For Function App"
+  condition: and(succeeded(), eq(variables['DeployInfra'], 'true'))
+  inputs:
+    azureSubscription: "${{ parameters.SubscriptionName }}"
+    scriptType: pscore
+    scriptPath: "$(Pipeline.Workspace)/AzDocs/Functions/Set-App-Key-to-Function-App.ps1"
+    arguments: >
+      -FunctionAppResourceGroupName '$(FunctionAppResourceGroupName)' 
+      -FunctionAppName '$(FunctionAppName)' 
+      -FunctionAppAppKeyName $(FunctionAppAppKeyName) 
+      -FunctionAppAppKeyType $(FunctionAppAppKeyType) 
+      -FunctionAppDeploymentSlotName $(FunctionAppDeploymentSlotName) 
+      -ApplyToAllSlots $(ApplyToAllSlots) 
+      -RetryApplyToAllSlotsCount $(RetryApplyToAllSlotsCount)
+
+```
+
+# Code
+
+[Click here to download this script](../../../../src/Functions/Set-App-Key-to-Function-App.ps1)
+
+[Click here to go to azure cli documentation](https://docs.microsoft.com/en-us/cli/azure/functionapp/keys?view=azure-cli-latest#az-functionapp-keys-set )

--- a/Wiki/Azure/CHANGELOG.md
+++ b/Wiki/Azure/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2022.01.21]
+
+## Breaking Changes
+
+- Removed `DisableDiagnosticSettings` from `Create-AppInsights-Resource.ps1`. Diagnostic settings will no be disabled by default for an App Insights resource. Added the possibility to add these Diagnostic settings to a separate workspace by using the parameter `DiagnosticSettingsLogAnalyticsWorkspaceResourceId`.
+
 ## [2022.01.18]
 
 - Fixed `Create-Cost-Alert.ps1`

--- a/Wiki/Azure/Documentation/Setup-Dependabot-in-Azure-DevOps.md
+++ b/Wiki/Azure/Documentation/Setup-Dependabot-in-Azure-DevOps.md
@@ -66,6 +66,15 @@ If your projects makes use of your own private nuget feeds (Azure Artifacts), ma
 - Add the environment variable defined above (`PATForNugetFeed`).
 - Fill in the variable `privateNugetFeedUrl`. Your nuget feed url can be found by going to `Artifacts` > `Connect to feed` > `dotnet`.
 
+### Skipping packages to update
+
+If you want some packages to be skipped by default for updating, make sure to add the `PackagesToIgnore` parameter.
+The value to fill it with looks like this:
+
+`'[{"dependency-name":"Microsoft.Azure.WebJobs.Extensions.Storage"}]'`
+
+For more information, please visit the github for the dependabot extensions which can be found below.
+
 ### Repositories
 
 At the end of the pipeline, the template `dependabot-pipeline.yml` is being called.
@@ -77,11 +86,15 @@ At the end of the pipeline, the template `dependabot-pipeline.yml` is being call
                 - Repository: "repository-1"
                 - Repository: "repository-2"
                   Directory: "/src"
+                  TargetBranch: "feature/test"
+                  PackagesToIgnore: "$(packagesToIgnore)"
 ```
 
 This template will be used to run the dependabot against multiple repositories. The repositories can be specified by adding them to Repositories parameter.
 
 If no `Directory` is provided, the root of the repository will be used.
+If no `TargetBranch` is provided, the `main` branch of the repository will be used.
+If no `PackagesToIgnore` is provided, no packages will be ignored for updating.
 
 ### Debugging
 

--- a/src/AppInsights/Create-AppInsights-Resource.ps1
+++ b/src/AppInsights/Create-AppInsights-Resource.ps1
@@ -7,13 +7,11 @@ param (
     [Parameter(Mandatory)][string] $LogAnalyticsWorkspaceResourceId,
 
     [Parameter()][System.Object[]] $ResourceTags,
-    
-    # Diagnostic settings
-    [Parameter()][System.Object[]] $DiagnosticSettingsLogs,
-    [Parameter()][System.Object[]] $DiagnosticSettingsMetrics,
 
-    # Disable diagnostic settings
-    [Parameter()][switch] $DiagnosticSettingsDisabled
+    # Diagnostic settings
+    [Parameter()][string] $DiagnosticSettingsLogAnalyticsWorkspaceResourceId,
+    [Parameter()][System.Object[]] $DiagnosticSettingsLogs,
+    [Parameter()][System.Object[]] $DiagnosticSettingsMetrics
 )
 
 #region ===BEGIN IMPORTS===
@@ -35,13 +33,9 @@ if ($ResourceTags)
 }
 
 # Add diagnostic settings to Application Insights
-if ($DiagnosticSettingsDisabled)
+if ($DiagnosticSettingsLogAnalyticsWorkspaceResourceId)
 {
-    Remove-DiagnosticSetting -ResourceId $applicationInsightsId -LogAnalyticsWorkspaceResourceId $LogAnalyticsWorkspaceResourceId -ResourceName $AppInsightsName
-}
-else
-{
-    Set-DiagnosticSettings -ResourceId $applicationInsightsId -ResourceName $AppInsightsName -LogAnalyticsWorkspaceResourceId $LogAnalyticsWorkspaceResourceId -DiagnosticSettingsLogs:$DiagnosticSettingsLogs -DiagnosticSettingsMetrics:$DiagnosticSettingsMetrics 
+    Set-DiagnosticSettings -ResourceId $applicationInsightsId -ResourceName $AppInsightsName -LogAnalyticsWorkspaceResourceId $DiagnosticSettingsLogAnalyticsWorkspaceResourceId -DiagnosticSettingsLogs:$DiagnosticSettingsLogs -DiagnosticSettingsMetrics:$DiagnosticSettingsMetrics 
 }
 
 $instrumentationKey = (Invoke-Executable az resource show --resource-group $AppInsightsResourceGroupName --name $AppInsightsName --resource-type "Microsoft.Insights/components" | ConvertFrom-Json).properties.InstrumentationKey

--- a/src/Functions/Set-App-Key-on-Function-App.ps1
+++ b/src/Functions/Set-App-Key-on-Function-App.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)][string] $FunctionAppResourceGroupName,
+    [Parameter(Mandatory)][string] $FunctionAppName,
+    [Parameter(Mandatory)][string] $FunctionAppAppKeyName,
+    [Parameter()][string] $FunctionAppAppKeyValue,
+    [Parameter()][ValidateSet("functionKeys", "masterKey", "systemKey")][string] $FunctionAppAppKeyType = "functionKeys",
+    [Parameter()][string] $FunctionAppDeploymentSlotName,
+    [Parameter()][bool] $ApplyToAllSlots = $false,
+    [Parameter()][int] $RetryApplyToAllSlotsCount = 3
+)
+
+#region ===BEGIN IMPORTS===
+Import-Module "$PSScriptRoot\..\AzDocs.Common" -Force
+#endregion ===END IMPORTS===
+
+Write-Header -ScopedPSCmdlet $PSCmdlet
+
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory)][string] $ExecutableLiteralPath,
+        [Parameter(ValueFromRemainingArguments)] $ExecutableArguments,
+        [Parameter()][int] $retries = 3
+    )
+
+    $retryCount = 0
+    $success = $false
+    while ($retryCount++ -lt $retries -and (-not $success))
+    {
+        try 
+        {
+            $result = Invoke-Executable -ExecutableLiteralPath $ExecutableLiteralPath @ExecutableArguments
+            $success = $true
+        }
+        catch
+        {
+            Start-Sleep -Seconds (($retryCount + 1) * 5)
+        }
+    }
+
+    $success
+    $result
+}
+
+if ($ApplyToAllSlots)
+{
+    $availableSlots = Invoke-Executable -AllowToFail az functionapp deployment slot list --name $FunctionAppName --resource-group $FunctionAppResourceGroupName | ConvertFrom-Json
+}
+
+$optionalParameters = @()
+if ($FunctionAppDeploymentSlotName)
+{
+    $optionalParameters += "--slot", "$FunctionAppDeploymentSlotName"
+}
+
+if ($FunctionAppAppKeyValue)
+{
+    $optionalParameters += "--key-value", "$FunctionAppAppKeyValue"
+}
+
+$setKeyResult = Invoke-Executable az functionapp keys set --key-name $FunctionAppAppKeyName --key-type $FunctionAppAppKeyType --name $FunctionAppName --resource-group $FunctionAppResourceGroupName @optionalSlotParameter @optionalParameters | ConvertFrom-Json
+$keyValue = $setKeyResult.properties.value
+
+Write-Output $keyValue
+
+foreach($availableSlot in $availableSlots)
+{
+    # Slot keys can not be modified if slot is stopped
+    $stopSlot = $false
+    if ($availableSlot.State -eq "Stopped")
+    {
+        $stopSlot = $true
+        Invoke-Executable az functionapp start --name $FunctionAppName --resource-group $FunctionAppResourceGroupName --slot $availableSlot.name
+        Start-Sleep -Seconds 1
+    }
+
+    $success = (Invoke-WithRetry -retries $RetryApplyToAllSlotsCount az functionapp keys set --key-name $FunctionAppAppKeyName --key-type $FunctionAppAppKeyType --name $FunctionAppName --resource-group $FunctionAppResourceGroupName --slot $availableSlot.name --key-value $keyValue)[0]
+
+    if ($stopSlot) 
+    {
+        Invoke-Executable az functionapp stop --name $FunctionAppName --resource-group $FunctionAppResourceGroupName --slot $availableSlot.name
+    }
+
+    if (-not $success)
+    {
+        throw "Failed to apply key to $($availableSlot.name) slot"
+    }
+}
+
+Write-Footer -ScopedPSCmdlet $PSCmdlet


### PR DESCRIPTION
## [2022.01.21]

## Breaking Changes

- Removed `DisableDiagnosticSettings` from `Create-AppInsights-Resource.ps1`. Diagnostic settings will now be disabled by default for an App Insights resource. Added the possibility to add these Diagnostic settings to a separate workspace by using the parameter `DiagnosticSettingsLogAnalyticsWorkspaceResourceId`.
